### PR TITLE
Handle null lastGc

### DIFF
--- a/src/main/java/org/elasticsearch/service/graphite/GraphiteReporter.java
+++ b/src/main/java/org/elasticsearch/service/graphite/GraphiteReporter.java
@@ -196,12 +196,14 @@ public class GraphiteReporter {
 
             JvmStats.GarbageCollector.LastGc lastGc = collector.lastGc();
             String lastGcType = type + ".lastGc";
-            sendInt(lastGcType, "startTime", lastGc.startTime());
-            sendInt(lastGcType, "endTime", lastGc.endTime());
-            sendInt(lastGcType, "max", lastGc.max().bytes());
-            sendInt(lastGcType, "beforeUsed", lastGc.beforeUsed().bytes());
-            sendInt(lastGcType, "afterUsed", lastGc.afterUsed().bytes());
-            sendInt(lastGcType, "durationSeconds", lastGc.duration().seconds());
+            if (lastGc != null) {
+                sendInt(lastGcType, "startTime", lastGc.startTime());
+                sendInt(lastGcType, "endTime", lastGc.endTime());
+                sendInt(lastGcType, "max", lastGc.max().bytes());
+                sendInt(lastGcType, "beforeUsed", lastGc.beforeUsed().bytes());
+                sendInt(lastGcType, "afterUsed", lastGc.afterUsed().bytes());
+                sendInt(lastGcType, "durationSeconds", lastGc.duration().seconds());
+            }
         }
 
         // TODO: bufferPools - where to get them?


### PR DESCRIPTION
Hey there!

After installing the plugin and enabling DEBUG logging, I was seeing stacktraces in the elasticsearch log:

```
[2013-04-09 21:36:31,846][DEBUG][org.elasticsearch.service.graphite.GraphiteReporter] Error writing to Graphite
java.lang.NullPointerException
        at org.elasticsearch.service.graphite.GraphiteReporter.sendNodeJvmStats(GraphiteReporter.java:199)
        at org.elasticsearch.service.graphite.GraphiteReporter.sendNodeStats(GraphiteReporter.java:83)
        at org.elasticsearch.service.graphite.GraphiteReporter.run(GraphiteReporter.java:68)
        at org.elasticsearch.service.graphite.GraphiteService$GraphiteReporterThread.run(GraphiteService.java:87)
        at java.lang.Thread.run(Thread.java:679)
```

It looks like `lastGc` is null. Digging into the elasticsearch source, it appears that this is a valid state (see: https://github.com/elasticsearch/elasticsearch/blob/master/src/main/java/org/elasticsearch/monitor/jvm/JvmMonitorService.java#L184)

What do you think? Is this guard the right way to prevent this NPE, or is there some other better way to fix this?

Thanks a bunch for the plugin!

Blake
