### PR TITLE
Add field data stats

### DIFF
--- a/src/main/java/org/elasticsearch/service/graphite/GraphiteReporter.java
+++ b/src/main/java/org/elasticsearch/service/graphite/GraphiteReporter.java
@@ -6,6 +6,7 @@ import org.elasticsearch.common.logging.ESLoggerFactory;
 import org.elasticsearch.http.HttpStats;
 import org.elasticsearch.index.cache.filter.FilterCacheStats;
 import org.elasticsearch.index.cache.id.IdCacheStats;
+import org.elasticsearch.index.fielddata.FieldDataStats;
 import org.elasticsearch.index.flush.FlushStats;
 import org.elasticsearch.index.get.GetStats;
 import org.elasticsearch.index.indexing.IndexingStats;
@@ -300,6 +301,7 @@ public class GraphiteReporter {
         sendIndexingStats(type + ".indexing", nodeIndicesStats.getIndexing());
         sendRefreshStats(type + ".refresh", nodeIndicesStats.getRefresh());
         sendSearchStats(type + ".search", nodeIndicesStats.getSearch());
+        sendFieldDataStats(type + ".fielddata", nodeIndicesStats.getFieldData());
     }
 
     private void sendSearchStats(String type, SearchStats searchStats) {
@@ -374,6 +376,11 @@ public class GraphiteReporter {
     private void sendFilterCacheStats(String name, FilterCacheStats filterCache) {
         sendInt(name, "memorySizeInBytes", filterCache.getMemorySizeInBytes());
         sendInt(name, "evictions", filterCache.getEvictions());
+    }
+
+    private void sendFieldDataStats(String name, FieldDataStats fieldDataStats) {
+        sendInt(name, "memorySizeInBytes", fieldDataStats.getMemorySizeInBytes());
+        sendInt(name, "evictions", fieldDataStats.getEvictions());
     }
 
     protected void sendToGraphite(String name, String value) {


### PR DESCRIPTION
I initially thought I was not getting field data stats since I was still on 0.90, but after finally upgrading to 1.1 I noticed those stats where still not appearing. Easy fix.

Node stats still not collected: store, merges, warmer, percolate, completion, segments, translog. Merges might be helpful. Going to try locally for a couple of weeks to see if they are useful.
