### PR TITLE
Prefix twice at search path

### DIFF
--- a/src/main/java/org/elasticsearch/service/graphite/GraphiteReporter.java
+++ b/src/main/java/org/elasticsearch/service/graphite/GraphiteReporter.java
@@ -315,8 +315,7 @@ public class GraphiteReporter {
         }
     }
 
-    private void sendSearchStatsStats(String group, SearchStats.Stats searchStats) {
-        String type = buildMetricName("search.stats.") + group;
+    private void sendSearchStatsStats(String type, SearchStats.Stats searchStats) {
         sendInt(type, "queryCount", searchStats.getQueryCount());
         sendInt(type, "queryTimeInMillis", searchStats.getQueryTimeInMillis());
         sendInt(type, "queryCurrent", searchStats.getQueryCurrent());

--- a/src/test/java/org/elasticsearch/module/graphite/test/GraphitePluginIntegrationTest.java
+++ b/src/test/java/org/elasticsearch/module/graphite/test/GraphitePluginIntegrationTest.java
@@ -1,6 +1,7 @@
 package org.elasticsearch.module.graphite.test;
 
 import org.elasticsearch.action.index.IndexResponse;
+import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.collect.Iterables;
 import org.elasticsearch.common.inject.ProvisionException;
 import org.elasticsearch.node.Node;
@@ -52,7 +53,9 @@ public class GraphitePluginIntegrationTest {
         ensureValidKeyNames();
         assertGraphiteMetricIsContained("elasticsearch." + clusterName + ".indexes." + index + ".id.0.indexing._all.indexCount 1");
         assertGraphiteMetricIsContained("elasticsearch." + clusterName + ".indexes." + index + ".id.0.indexing." + type + ".indexCount 1");
+        assertGraphiteMetricIsContained("elasticsearch." + clusterName + ".indexes." + index + ".id.0.search._all.queryCount ");
         assertGraphiteMetricIsContained("elasticsearch." + clusterName + ".node.jvm.threads.peakCount ");
+        assertGraphiteMetricIsContained("elasticsearch." + clusterName + ".node.search._all.queryCount ");
     }
 
     @Test
@@ -97,6 +100,9 @@ public class GraphitePluginIntegrationTest {
 
         IndexResponse indexResponse = indexElement(node, index, type, "value");
         assertThat(indexResponse.getId(), is(notNullValue()));
+
+        SearchResponse searchResponse = searchElement(node);
+        assertThat(searchResponse.status(), is(notNullValue()));
 
         Thread.sleep(2000);
 
@@ -154,5 +160,9 @@ public class GraphitePluginIntegrationTest {
         return node.client().prepareIndex(index, type).
                 setSource("field", fieldValue)
                 .execute().actionGet();
+    }
+
+    private SearchResponse  searchElement(Node node) {
+        return node.client().prepareSearch().execute().actionGet();
     }
 }


### PR DESCRIPTION
At search path there is bug where prefix is added twice.

elasticsearch.79bb6ff767e04e85b01ec56e57e9b125.search.stats.elasticsearch.79bb6ff767e04e85b01ec56e57e9b125.indexes.4dfc7159bde44155b68e83ef8a12995b.id.0.search._all.fetchTimeInMillis

This patch set fixes that and adds tests.